### PR TITLE
XMLHttpRequest is not handled properly in `WaveformData.create` with IE9

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -81,7 +81,7 @@ WaveformData.create = function createFromResponseData(data){
   var adapter = null;
   var xhrData = null;
 
-  if (data && typeof data === "object" && "response" in data){
+  if (data && typeof data === "object" && ("responseText" in data || "response" in data)){
     xhrData = ("responseType" in data) ? data.response : (data.responseText || data.response);
   }
 


### PR DESCRIPTION
This seems to do the trick, as `response` is not in the XHR response.

``` js
if (data && typeof data === "object" && ("response" in data || "responseText" in data))
```
