### PR TITLE
Added normal array & for loop in offsetValues

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -344,16 +344,15 @@ WaveformData.prototype = {
    */
   offsetValues: function getOffsetValues(start, length, correction){
     var adapter = this.adapter;
-
-    //creating a dense array on the fly for an optimized loop
-    //@see http://www.2ality.com/2012/06/dense-arrays.html
-    var values = Array.apply(null, new Array(length));
+    var values = [];
 
     correction += (start * 2);  //offsetting the positioning query
 
-    return values.map(function offsetValueMapper(val, i){
-      return adapter.at((i * 2) + correction);
-    });
+    for (var i = 0; i < length; i++){
+      values.push(adapter.at((i * 2) + correction));
+    }
+
+    return values;
   },
   /**
    * Compute the duration in seconds of the audio file.


### PR DESCRIPTION
Replaced dense array in `offsetValues` function to use a normal array
and for loop to prevent the call stack from exceeding it’s limit.

See related issue #15
