### PR TITLE
Adding detailed docs on how to generate waveform data in the client using AJAX or fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ xhr.responseType = "arraybuffer";
 xhr.addEventListener("load", function onResponse(progressEvent){
   WaveformData.builders.webaudio(audioContext, progressEvent.target.response, onProcessed(err, waveform){
     if (err) {
-       console.error(err);
-       return;
+      console.error(err);
+        return;
     }
     
     console.log(waveform.duration);

--- a/README.md
+++ b/README.md
@@ -89,13 +89,40 @@ Web Audio is an HTML5 API which can help fetch the waveform from the file direct
 ```javascript
 const webAudioBuilder = require('waveform-data/webaudio');
 const audioContext = new AudioContext();
+```
 
-xhr.open("GET", "http://example.com/some/file.mp3");
+### With AJAX
 
-fetch('http://example.com/waveforms/track.dat')
+```javascript
+xhr.open("GET", "http://example.com/audio/track.ogg");
+xhr.responseType = "arraybuffer";
+
+xhr.addEventListener("load", function onResponse(progressEvent){
+  WaveformData.builders.webaudio(audioContext, progressEvent.target.response, onProcessed(err, waveform){
+    if (err) {
+       console.error(err);
+       return;
+    }
+    
+    console.log(waveform.duration);
+  });
+});
+
+xhr.send();
+```
+
+### With `fetch`
+
+```javascript
+fetch('http://example.com/audio/track.ogg')
   .then(response => response.arrayBuffer())
   .then(buffer => {
-    webAudioBuilder(audioContext, buffer, (error, waveform) => {
+    webAudioBuilder(audioContext, buffer, (err, waveform) => {
+      if (err) {
+         console.error(err);
+         return;
+      }
+      
       console.log(waveform.duration);
     });
   });

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ fetch('http://example.com/audio/track.ogg')
   .then(buffer => {
     webAudioBuilder(audioContext, buffer, (err, waveform) => {
       if (err) {
-         console.error(err);
-         return;
+        console.error(err);
+        return;
       }
       
       console.log(waveform.duration);


### PR DESCRIPTION
I noticed that the docs for the webaudio portion were a little off. This request adds two full examples for both xhr and fetch, and corrects the example url that kinda sorta hinted that you needed to download the audio via xhr and a waveform data file via fetch.