### PR TITLE
🐛 Fix drawing waveform in canvas example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ waveform.max.reverse().forEach((val, x) => {
 });
 
 ctx.closePath();
-canvas.fillStroke();
+ctx.strokeStyle="#000";
+ctx.stroke();
 ```
 
 ## Drawing in D3


### PR DESCRIPTION
Hi, 

Thanks for this amazing library! It works very well and has helped me quite a lot to understand how waveforms work 👏

I was glancing at the `README.md` file and saw `canvas.fillStroke()` in one of the examples. It doesn't seem to exist. I've updated the example and tested if the snippet worked.