### PR TITLE
Expose method to create waveform from AudioBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ fetch('https://example.com/audio/track.ogg')
   });
 ```
 
+### With decoded AudioBuffer
+```javascript
+const webAudioBuilder = require('waveform-data/webaudio');
+const audioContext = new AudioContext();
+
+audioContext.decodeAudioData(arrayBuffer, (audioBuffer) => {
+  webAudioBuilder.fromAudioBuffer(audioBuffer, {}, (err, waveform) => {
+      console.log('waveform', waveform);
+  });
+})
+```
+
 ## Drawing in canvas
 
 ```javascript

--- a/lib/builders/audiobuffer.js
+++ b/lib/builders/audiobuffer.js
@@ -1,10 +1,11 @@
 "use strict";
 
 var getAudioDecoder = require("./audiodecoder");
-var getOptions = require('./options');
+var getOptions = require("./options");
 
 function fromAudioBuffer(audioBuffer, options, callback) {
     var opts = getOptions(options, callback);
+
     return getAudioDecoder(opts.options, opts.callback)(audioBuffer);
 }
 

--- a/lib/builders/audiobuffer.js
+++ b/lib/builders/audiobuffer.js
@@ -4,9 +4,9 @@ var getAudioDecoder = require("./audiodecoder");
 var getOptions = require("./options");
 
 function fromAudioBuffer(audioBuffer, options, callback) {
-    var opts = getOptions(options, callback);
+  var opts = getOptions(options, callback);
 
-    return getAudioDecoder(opts.options, opts.callback)(audioBuffer);
+  return getAudioDecoder(opts.options, opts.callback)(audioBuffer);
 }
 
 module.exports = fromAudioBuffer;

--- a/lib/builders/audiobuffer.js
+++ b/lib/builders/audiobuffer.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var getAudioDecoder = require("./audiodecoder");
+var getOptions = require('./options');
+
+function fromAudioBuffer(audioBuffer, options, callback) {
+    var opts = getOptions(options, callback);
+    return getAudioDecoder(opts.options, opts.callback)(audioBuffer);
+}
+
+module.exports = fromAudioBuffer;

--- a/lib/builders/options.js
+++ b/lib/builders/options.js
@@ -24,7 +24,7 @@ function getOptions(options, callback) {
 
     return {
         options: options,
-        callback: callback,
+        callback: callback
     };
 }
 

--- a/lib/builders/options.js
+++ b/lib/builders/options.js
@@ -1,0 +1,31 @@
+"use strict";
+
+function getOptions(options, callback) {
+    var defaultOptions = {
+        scale: 512,
+        amplitude_scale: 1.0
+    };
+
+    // fromAudioObjectBuilder(audioContext, data, callback) form
+    if (typeof options === "function") {
+        callback = options;
+        options = {};
+    }
+    else {
+        options = options || {};
+    }
+
+    options.scale = options.scale || defaultOptions.scale;
+    options.amplitude_scale = options.amplitude_scale || defaultOptions.amplitude_scale;
+
+    if (options.hasOwnProperty("scale_adjuster")) {
+        throw new Error("Please rename the 'scale_adjuster' option to 'amplitude_scale'");
+    }
+
+    return {
+        options: options,
+        callback: callback,
+    };
+}
+
+module.exports = getOptions;

--- a/lib/builders/options.js
+++ b/lib/builders/options.js
@@ -1,31 +1,31 @@
 "use strict";
 
 function getOptions(options, callback) {
-    var defaultOptions = {
-        scale: 512,
-        amplitude_scale: 1.0
-    };
+  var defaultOptions = {
+    scale: 512,
+    amplitude_scale: 1.0
+  };
 
-    // fromAudioObjectBuilder(audioContext, data, callback) form
-    if (typeof options === "function") {
-        callback = options;
-        options = {};
-    }
-    else {
-        options = options || {};
-    }
+  // fromAudioObjectBuilder(audioContext, data, callback) form
+  if (typeof options === "function") {
+    callback = options;
+    options = {};
+  }
+  else {
+    options = options || {};
+  }
 
-    options.scale = options.scale || defaultOptions.scale;
-    options.amplitude_scale = options.amplitude_scale || defaultOptions.amplitude_scale;
+  options.scale = options.scale || defaultOptions.scale;
+  options.amplitude_scale = options.amplitude_scale || defaultOptions.amplitude_scale;
 
-    if (options.hasOwnProperty("scale_adjuster")) {
-        throw new Error("Please rename the 'scale_adjuster' option to 'amplitude_scale'");
-    }
+  if (options.hasOwnProperty("scale_adjuster")) {
+    throw new Error("Please rename the 'scale_adjuster' option to 'amplitude_scale'");
+  }
 
-    return {
-        options: options,
-        callback: callback
-    };
+  return {
+    options: options,
+    callback: callback
+  };
 }
 
 module.exports = getOptions;

--- a/lib/builders/webaudio.js
+++ b/lib/builders/webaudio.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var getAudioDecoder = require("./audiodecoder");
+var getOptions = require('./options');
 
 /**
  * Creates a working WaveformData based on binary audio data.
@@ -42,31 +43,13 @@ var getAudioDecoder = require("./audiodecoder");
 
 function fromAudioObjectBuilder(audio_context, raw_response, options, callback) {
   var audioContext = window.AudioContext || window.webkitAudioContext;
-  var defaultOptions = {
-    scale: 512,
-    amplitude_scale: 1.0
-  };
-
   if (!(audio_context instanceof audioContext)) {
     throw new TypeError("First argument should be an AudioContext instance");
   }
 
-  // fromAudioObjectBuilder(audioContext, data, callback) form
-  if (typeof options === "function") {
-    callback = options;
-    options = {};
-  }
-  else {
-    options = options || {};
-  }
-
-  options.scale = options.scale || defaultOptions.scale;
-  options.amplitude_scale = options.amplitude_scale || defaultOptions.amplitude_scale;
-
-  if (options.hasOwnProperty("scale_adjuster")) {
-    throw new Error("Please rename the 'scale_adjuster' option to 'amplitude_scale'");
-  }
-
+  var opts = getOptions(options, callback);
+  callback = opts.callback;
+  options = opts.options;
   // The following function is a workaround for a Webkit bug where decodeAudioData
   // invokes the errorCallback with null instead of a DOMException.
   // See https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-decodeaudiodata

--- a/lib/builders/webaudio.js
+++ b/lib/builders/webaudio.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var getAudioDecoder = require("./audiodecoder");
-var getOptions = require('./options');
+var getOptions = require("./options");
 
 /**
  * Creates a working WaveformData based on binary audio data.
@@ -43,11 +43,13 @@ var getOptions = require('./options');
 
 function fromAudioObjectBuilder(audio_context, raw_response, options, callback) {
   var audioContext = window.AudioContext || window.webkitAudioContext;
+
   if (!(audio_context instanceof audioContext)) {
     throw new TypeError("First argument should be an AudioContext instance");
   }
 
   var opts = getOptions(options, callback);
+
   callback = opts.callback;
   options = opts.options;
   // The following function is a workaround for a Webkit bug where decodeAudioData

--- a/test/unit/builders/audiobuffer.js
+++ b/test/unit/builders/audiobuffer.js
@@ -1,0 +1,111 @@
+"use strict";
+
+/* globals describe, it, beforeEach, DOMException, __dirname */
+
+var fromAudioBuffer = require("../../../lib/builders/audiobuffer");
+var AudioWaveform = require("../../../waveform-data");
+
+var chai = require("chai");
+var fs = require("fs");
+var sinonChai = require("sinon-chai");
+var expect = chai.expect;
+
+chai.use(sinonChai);
+
+describe("WaveformData AudioBuffer builder", function() {
+  var sampleAudioBuffer;
+  var AudioContext = window.AudioContext || window.webkitAudioContext;
+  var audioContext = new AudioContext();
+
+  beforeEach(function(done) {
+    fs.readFile(__dirname + "/../../4channel.wav", function(err, buf) {
+      audioContext.decodeAudioData(buf.buffer, (audioBuffer) => {
+        sampleAudioBuffer = audioBuffer;
+        done();
+      });
+    });
+  });
+
+  describe("factory", function() {
+    it("should return a valid waveform in case of success", function(done) {
+      var result = fromAudioBuffer(sampleAudioBuffer, function(err, waveform) {
+        expect(err).to.not.be.ok;
+        expect(waveform).to.be.an.instanceOf(AudioWaveform);
+        expect(waveform).to.have.property("offset_length");
+
+        // file length: 88200 samples
+        // scale: 512 (default)
+        // 88200 / 512 = 172, with 136 samples remaining, so 173 points total
+        expect(waveform.offset_length).to.equal(173);
+        done();
+      });
+
+      if (result && "then" in result) {
+        result.catch(console.error.message);
+      }
+    });
+
+    it("should adjust the length of the waveform when using a different scale", function(done) {
+      var options = { scale: 128 };
+
+      var result = fromAudioBuffer(sampleAudioBuffer, options, function(err, waveform) {
+        expect(err).to.not.be.ok;
+        expect(waveform).to.have.property("offset_length");
+
+        // file length: 88200 samples
+        // scale: 128
+        // 88200 / 128 = 689, with 8 samples remaining, so 690 points total
+        expect(waveform.offset_length).to.equal(690);
+        done();
+      });
+
+      if (result && "then" in result) {
+        result.catch(console.error.message);
+      }
+    });
+
+    it("should return waveform data points", function(done) {
+      var result = fromAudioBuffer(sampleAudioBuffer, function(err, waveform) {
+        expect(err).to.not.be.ok;
+
+        expect(waveform.min[0]).to.equal(-23);
+        expect(waveform.max[0]).to.equal(22);
+
+        expect(waveform.min[waveform.offset_length - 1]).to.equal(-23);
+        expect(waveform.max[waveform.offset_length - 1]).to.equal(22);
+        done();
+      });
+
+      if (result && "then" in result) {
+        result.catch(console.error.message);
+      }
+    });
+
+    it("should return correctly scaled waveform data points", function(done) {
+      var options = { amplitude_scale: 2.0 };
+
+      var result = fromAudioBuffer(sampleAudioBuffer, options, function(err, waveform) {
+        expect(err).to.not.be.ok;
+
+        expect(waveform.min[0]).to.equal(-45);
+        expect(waveform.max[0]).to.equal(44);
+
+        expect(waveform.min[waveform.offset_length - 1]).to.equal(-45);
+        expect(waveform.max[waveform.offset_length - 1]).to.equal(44);
+        done();
+      });
+
+      if (result && "then" in result) {
+        result.catch(console.error.message);
+      }
+    });
+
+    it("should return an error if the scale_adjuster parameter is present", function() {
+      var options = { scale_adjuster: 127 };
+
+      expect(function() {
+        fromAudioBuffer(sampleAudioBuffer, options);
+      }).to.throw(Error, /scale_adjuster/);
+    });
+  });
+});

--- a/webaudio.js
+++ b/webaudio.js
@@ -1,5 +1,9 @@
 "use strict";
 
 var webAudioBuilder = require("./lib/builders/webaudio");
+var fromAudioBuffer = require("./lib/builders/audiobuffer");
+
+
+webAudioBuilder.fromAudioBuffer = fromAudioBuffer;
 
 module.exports = webAudioBuilder;


### PR DESCRIPTION
Fixes https://github.com/bbc/waveform-data.js/issues/53

- Exposes `fromAudioBuffer` method on exported object from `waveform-data/webaudio`
- Refactored `options` logic to own module to share between `fromAudioBuffer` and `webAudioBuilder`

```javascript
const webAudioBuilder = require('waveform-data/webaudio');
const audioContext = new AudioContext();
audioContext.decodeAudioData(arrayBuffer, (audioBuffer) => {
  webAudioBuilder.fromAudioBuffer(audioBuffer, {}, (err, waveform) => {
      console.log('waveform', waveform);
  });
})
```

cc @floydback