### PR TITLE
Add WaveformData.concat() to combine waveforms

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -14,6 +14,7 @@
   * [.channels](#waveformDatachannels)
   * [.channel](#waveformDatachannelindex)
   * [.resample](#waveformDataresampleoptions)
+  * [.concat](#waveformDataconcatwaveforms)
 * [WaveformDataChannel](#waveformdatachannel)
   * [.min_sample](#waveformDataChannelmin_sampleindex)
   * [.max_sample](#waveformDataChannelmax_sampleindex)
@@ -29,7 +30,7 @@ display the waveform at zoom levels or fit to a given width.
 It also allows you to create waveform data from audio content using the Web
 Audio API.
 
-### waveformData.create(data)
+### WaveformData.create(data)
 
 Creates and returns a [`WaveformData`](#waveformdata) instance from the given
 data, which may be in binary (.dat) format in an
@@ -75,7 +76,7 @@ fetch('http://example.com/waveforms/track.json')
 Note that previous (v1.x) versions of **waveform-data.js** would accept JSON
 strings as input, but this is not supported from v2.0 onwards.
 
-### waveformData.createFromAudio(options, callback)
+### WaveformData.createFromAudio(options, callback)
 
 Creates a [`WaveformData`](#waveformdata) object from audio using the Web
 Audio API.
@@ -385,6 +386,36 @@ frame.
 const waveform = WaveformData.create(buffer);
 const resampledWaveform = waveform.resample({ width: 500, from: 0, to: 500 });
 ```
+
+### waveformData.concat(...waveforms)
+
+Concatenates the receiver with one or more other waveforms, returning a new
+[`WaveformData`](#waveformdata) object.
+The waveforms must be compatible objects (for instance, joining mono to stereo
+waveforms is not supported).
+
+#### Arguments
+
+| Name          | Type                                 |
+| ------------- | ------------------------------------ |
+| ...waveforms  | One or more `WaveformData` instances |
+
+#### Examples
+
+To combine three waveforms into one long one:
+
+```javascript
+const wave1 = WaveformData.create(buffer1);
+const wave2 = WaveformData.create(buffer2);
+const wave3 = WaveformData.create(buffer3);
+const combinedResult = wave1.concat(wave2, wave3);
+
+console.log(wave1.length); // -> 500
+console.log(wave2.length); // -> 300
+console.log(wave3.length); // -> 100
+console.log(combinedResult.length); // -> 900
+```
+
 
 ## WaveformDataChannel
 

--- a/lib/adapters/arraybuffer.js
+++ b/lib/adapters/arraybuffer.js
@@ -122,6 +122,53 @@ WaveformDataArrayBufferAdapter.isCompatible = function isCompatible(data) {
 
   at: function at_sample(index) {
     return this._data.getInt8(this._offset + index);
+  },
+
+  /**
+   * Returns a new ArrayBuffer with the concatenated waveform.
+   * All waveforms must have identical metadata (version, channels, etc)
+   *
+   * @param {...WaveformDataArrayBufferAdapter} otherAdapters One or more adapters to concatenate
+   * @return {ArrayBuffer} concatenated ArrayBuffer
+   */
+
+  concatBuffers: function() {
+    var otherAdapters = Array.prototype.slice.call(arguments);
+    var headerSize = this._offset;
+    var totalSize = headerSize;
+    var totalDataLength = 0;
+    var bufferCollection = [this].concat(otherAdapters).map(w => w._data.buffer);
+    var i, buffer;
+
+    for (i = 0; i < bufferCollection.length; i++) {
+      buffer = bufferCollection[i];
+      var dataSize = new DataView(buffer).getInt32(16, true);
+
+      totalSize += buffer.byteLength - headerSize;
+      totalDataLength += dataSize;
+    }
+
+    var totalBuffer = new ArrayBuffer(totalSize);
+    var sourceHeader = new DataView(bufferCollection[0]);
+    var totalBufferView = new DataView(totalBuffer);
+
+    // Copy the header from the first chunk
+    for (i = 0; i < headerSize; i++) {
+      totalBufferView.setUint8(i, sourceHeader.getUint8(i));
+    }
+    // Rewrite the data-length header item to reflect all of the samples concatenated together
+    totalBufferView.setInt32(16, totalDataLength, true);
+
+    var offset = 0;
+    var dataOfTotalBuffer = new Uint8Array(totalBuffer, headerSize);
+
+    for (i = 0; i < bufferCollection.length; i++) {
+      buffer = bufferCollection[i];
+      dataOfTotalBuffer.set(new Uint8Array(buffer, headerSize), offset);
+      offset += buffer.byteLength - headerSize;
+    }
+
+    return totalBuffer;
   }
 };
 

--- a/lib/adapters/object.js
+++ b/lib/adapters/object.js
@@ -114,6 +114,24 @@ WaveformDataObjectAdapter.prototype = {
     else {
       throw new RangeError("Invalid index: " + index);
     }
+  },
+
+  /**
+   * Returns a new data object with the concatenated waveform.
+   * Both waveforms must have identical metadata (version, channels, etc)
+   *
+   * @param {...WaveformDataObjectAdapter} otherAdapters One or more adapters
+   * @return {Mixed} combined waveform data
+   */
+
+  concatBuffers: function() {
+    var otherAdapters = Array.prototype.slice.call(arguments);
+    var otherDatas = otherAdapters.map(a => a._data.data);
+    var result = Object.assign({}, this._data);
+
+    result.data = result.data.concat.apply(result.data, otherDatas);
+    result.length += otherAdapters.reduce((sum, adapter) => sum + adapter.length, 0);
+    return result;
   }
 };
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -294,6 +294,32 @@ WaveformData.prototype = {
   },
 
   /**
+   * Return a new WaveformData instance with the concatenated result of multiple waveforms.
+   *
+   * @param {...WaveformData} otherWaveforms One or more waveform instances to concatenate
+   * @return {WaveformData} New concatenated object
+   */
+  concat: function() {
+    var otherWaveforms = Array.prototype.slice.call(arguments);
+
+    // Check that all the supplied waveforms are compatible
+    otherWaveforms.forEach((otherWaveform) => {
+      if (this.channels !== otherWaveform.channels ||
+        this.sample_rate !== otherWaveform.sample_rate ||
+        this.scale !== otherWaveform.scale ||
+        Object.getPrototypeOf(this._adapter) !== Object.getPrototypeOf(otherWaveform._adapter) ||
+        this._adapter.version !== otherWaveform._adapter.version) {
+        throw new Error("Waveforms are incompatible");
+      }
+    });
+
+    var otherAdapters = otherWaveforms.map(w => w._adapter);
+    var combinedBuffer = this._adapter.concatBuffers.apply(this._adapter, otherAdapters);
+
+    return new WaveformData(combinedBuffer);
+  },
+
+  /**
    * Return the unpacked values for a particular offset.
    *
    * @param {Integer} start

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -95,55 +95,6 @@ describe("WaveformData", function() {
       });
     });
 
-    describe(".concat", function() {
-      var binaryWaveform, jsonWaveform;
-
-      beforeEach(function() {
-        binaryWaveform = new WaveformData(fixtures.getBinaryData({ channels: 1 }));
-        jsonWaveform = new WaveformData(fixtures.getJSONData({ channels: 1 }));
-      });
-
-      it("should return a new WaveformData object with the concatenated result from binary data", function() {
-        var result = binaryWaveform.concat(binaryWaveform);
-
-        expect(result.channels).to.equal(1);
-        expect(result.length).to.equal(expectations.length * 2);
-        expect(result.duration).to.equal(expectations.duration * 2);
-        expect(result.channel(0).min_array()).to.deep.equal([0, -10, 0, -5, -5, 0, 0, 0, 0, -2, 0, -10, 0, -5, -5, 0, 0, 0, 0, -2]);
-      });
-
-      it("should return a new WaveformData object with the concatenated result from json data", function() {
-        var result = jsonWaveform.concat(jsonWaveform);
-
-        expect(result.channels).to.equal(1);
-        expect(result.length).to.equal(expectations.length * 2);
-        expect(result.duration).to.equal(expectations.duration * 2);
-        expect(result.channel(0).min_array()).to.deep.equal([0, -10, 0, -5, -5, 0, 0, 0, 0, -2, 0, -10, 0, -5, -5, 0, 0, 0, 0, -2]);
-      });
-
-      it("throws an error if passing incompatible adapters", function() {
-        expect(function() {
-          binaryWaveform.append(jsonWaveform);
-        }).to.throw(Error);
-      });
-
-      it("throws an error if passing incompatible audio", function() {
-        expect(function() {
-          let stereoWaveform = new WaveformData(fixtures.getBinaryData({ channels: 2 }));
-
-          binaryWaveform.concat(stereoWaveform);
-        }).to.throw(Error);
-      });
-
-      it("can append multiple WaveformDatas at once", function() {
-        var result = binaryWaveform.concat(binaryWaveform, binaryWaveform);
-
-        expect(result.channels).to.equal(1);
-        expect(result.length).to.equal(expectations.length * 3);
-        expect(result.duration).to.equal(expectations.duration * 3);
-      });
-    });
-
     describe("WaveformDataChannel", function() {
       describe(".min_array()", function() {
         it("should return an array containing the waveform minimum values", function() {
@@ -292,6 +243,55 @@ describe("WaveformData", function() {
 
           expect(data).to.have.a.lengthOf(3);
         });
+      });
+    });
+
+    describe(".concat()", function() {
+      var binaryWaveform, jsonWaveform;
+
+      beforeEach(function() {
+        binaryWaveform = new WaveformData(fixtures.getBinaryData({ channels: 1 }));
+        jsonWaveform = new WaveformData(fixtures.getJSONData({ channels: 1 }));
+      });
+
+      it("should return a new WaveformData object with the concatenated result from binary data", function() {
+        var result = binaryWaveform.concat(binaryWaveform);
+
+        expect(result.channels).to.equal(1);
+        expect(result.length).to.equal(expectations.length * 2);
+        expect(result.duration).to.equal(expectations.duration * 2);
+        expect(result.channel(0).min_array()).to.deep.equal([0, -10, 0, -5, -5, 0, 0, 0, 0, -2, 0, -10, 0, -5, -5, 0, 0, 0, 0, -2]);
+      });
+
+      it("should return a new WaveformData object with the concatenated result from json data", function() {
+        var result = jsonWaveform.concat(jsonWaveform);
+
+        expect(result.channels).to.equal(1);
+        expect(result.length).to.equal(expectations.length * 2);
+        expect(result.duration).to.equal(expectations.duration * 2);
+        expect(result.channel(0).min_array()).to.deep.equal([0, -10, 0, -5, -5, 0, 0, 0, 0, -2, 0, -10, 0, -5, -5, 0, 0, 0, 0, -2]);
+      });
+
+      it("throws an error if passing incompatible adapters", function() {
+        expect(function() {
+          binaryWaveform.append(jsonWaveform);
+        }).to.throw(Error);
+      });
+
+      it("throws an error if passing incompatible audio", function() {
+        expect(function() {
+          let stereoWaveform = new WaveformData(fixtures.getBinaryData({ channels: 2 }));
+
+          binaryWaveform.concat(stereoWaveform);
+        }).to.throw(Error);
+      });
+
+      it("can append multiple WaveformDatas at once", function() {
+        var result = binaryWaveform.concat(binaryWaveform, binaryWaveform);
+
+        expect(result.channels).to.equal(1);
+        expect(result.length).to.equal(expectations.length * 3);
+        expect(result.duration).to.equal(expectations.duration * 3);
       });
     });
 
@@ -488,6 +488,55 @@ describe("WaveformData", function() {
 
           expect(data).to.have.a.lengthOf(3);
         });
+      });
+    });
+
+    describe(".concat()", function() {
+      var binaryWaveform, jsonWaveform;
+
+      beforeEach(function() {
+        binaryWaveform = new WaveformData(fixtures.getBinaryData({ channels: 2 }));
+        jsonWaveform = new WaveformData(fixtures.getJSONData({ channels: 2 }));
+      });
+
+      it("should return a new WaveformData object with the concatenated result from binary data", function() {
+        var result = binaryWaveform.concat(binaryWaveform);
+
+        expect(result.channels).to.equal(2);
+        expect(result.length).to.equal(expectations.length * 2);
+        expect(result.duration).to.equal(expectations.duration * 2);
+        expect(result.channel(0).min_array()).to.deep.equal([0, -10, 0, -5, -5, 0, 0, 0, 0, -2, 0, -10, 0, -5, -5, 0, 0, 0, 0, -2]);
+      });
+
+      it("should return a new WaveformData object with the concatenated result from json data", function() {
+        var result = jsonWaveform.concat(jsonWaveform);
+
+        expect(result.channels).to.equal(2);
+        expect(result.length).to.equal(expectations.length * 2);
+        expect(result.duration).to.equal(expectations.duration * 2);
+        expect(result.channel(0).min_array()).to.deep.equal([0, -10, 0, -5, -5, 0, 0, 0, 0, -2, 0, -10, 0, -5, -5, 0, 0, 0, 0, -2]);
+      });
+
+      it("throws an error if passing incompatible adapters", function() {
+        expect(function() {
+          binaryWaveform.append(jsonWaveform);
+        }).to.throw(Error);
+      });
+
+      it("throws an error if passing incompatible audio", function() {
+        expect(function() {
+          let stereoWaveform = new WaveformData(fixtures.getBinaryData({ channels: 1 }));
+
+          binaryWaveform.concat(stereoWaveform);
+        }).to.throw(Error);
+      });
+
+      it("can append multiple WaveformDatas at once", function() {
+        var result = binaryWaveform.concat(binaryWaveform, binaryWaveform);
+
+        expect(result.channels).to.equal(2);
+        expect(result.length).to.equal(expectations.length * 3);
+        expect(result.duration).to.equal(expectations.duration * 3);
       });
     });
 

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -70,7 +70,7 @@ describe("WaveformData", function() {
     beforeEach(function() {
       const data = fixtures.getBinaryData({ channels: 1 });
 
-      instance = new WaveformData(data, WaveformData);
+      instance = new WaveformData(data);
     });
 
     describe(".channels", function() {
@@ -92,6 +92,55 @@ describe("WaveformData", function() {
         expect(function() {
           instance.channel(-1);
         }).to.throw(RangeError);
+      });
+    });
+
+    describe(".concat", function() {
+      var binaryWaveform, jsonWaveform;
+
+      beforeEach(function() {
+        binaryWaveform = new WaveformData(fixtures.getBinaryData({ channels: 1 }));
+        jsonWaveform = new WaveformData(fixtures.getJSONData({ channels: 1 }));
+      });
+
+      it("should return a new WaveformData object with the concatenated result from binary data", function() {
+        var result = binaryWaveform.concat(binaryWaveform);
+
+        expect(result.channels).to.equal(1);
+        expect(result.length).to.equal(expectations.length * 2);
+        expect(result.duration).to.equal(expectations.duration * 2);
+        expect(result.channel(0).min_array()).to.deep.equal([0, -10, 0, -5, -5, 0, 0, 0, 0, -2, 0, -10, 0, -5, -5, 0, 0, 0, 0, -2]);
+      });
+
+      it("should return a new WaveformData object with the concatenated result from json data", function() {
+        var result = jsonWaveform.concat(jsonWaveform);
+
+        expect(result.channels).to.equal(1);
+        expect(result.length).to.equal(expectations.length * 2);
+        expect(result.duration).to.equal(expectations.duration * 2);
+        expect(result.channel(0).min_array()).to.deep.equal([0, -10, 0, -5, -5, 0, 0, 0, 0, -2, 0, -10, 0, -5, -5, 0, 0, 0, 0, -2]);
+      });
+
+      it("throws an error if passing incompatible adapters", function() {
+        expect(function() {
+          binaryWaveform.append(jsonWaveform);
+        }).to.throw(Error);
+      });
+
+      it("throws an error if passing incompatible audio", function() {
+        expect(function() {
+          let stereoWaveform = new WaveformData(fixtures.getBinaryData({ channels: 2 }));
+
+          binaryWaveform.concat(stereoWaveform);
+        }).to.throw(Error);
+      });
+
+      it("can append multiple WaveformDatas at once", function() {
+        var result = binaryWaveform.concat(binaryWaveform, binaryWaveform);
+
+        expect(result.channels).to.equal(1);
+        expect(result.length).to.equal(expectations.length * 3);
+        expect(result.duration).to.equal(expectations.duration * 3);
       });
     });
 


### PR DESCRIPTION
See #64 

Do you have opinions about using es6-y syntax in lib (eg https://github.com/jdelStrother/waveform-data.js/blob/ddab80f31e7c48af74d527a6692a33f3af3a2fae/lib/adapters/arraybuffer.js#L139) ?  I can rewrite it if you like, but we're already using `const` in a number of places.