### PR TITLE
Shared worker

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -83,6 +83,7 @@
     <script>
       let waveformData = null;
 
+      const AudioContext = window.AudioContext || window.webkitAudioContext;
       const canvas = document.getElementById('canvas');
       const slider = document.getElementById('offset');
 

--- a/lib/builders/audiodecoder.js
+++ b/lib/builders/audiodecoder.js
@@ -3,30 +3,13 @@
 var WaveformData = require("../core");
 var InlineWorker = require("inline-worker");
 
-/**
- * This callback is executed once the audio has been decoded by the browser and
- * resampled by waveform-data.
- *
- * @callback onAudioResampled
- * @param {Error?}
- * @param {WaveformData} waveform_data Waveform instance of the browser decoded audio
- * @param {AudioBuffer} audio_buffer Decoded audio buffer
- */
+var sharedWorker = null;
+var jobCallbacks = {};
+var jobId = 0;
 
-/**
- * AudioBuffer-based WaveformData generator
- *
- * Adapted from BlockFile::CalcSummary in Audacity, with permission.
- * @see https://code.google.com/p/audacity/source/browse/audacity-src/trunk/src/BlockFile.cpp
- *
- * @param {Object.<{scale: Number, amplitude_scale: Number, split_channels: Boolean}>} options
- * @param {onAudioResampled} callback
- * @returns {Function.<AudioBuffer>}
- */
-
-function getAudioDecoder(options, callback) {
-  return function onAudioDecoded(audio_buffer) {
-    var worker = new InlineWorker(function() {
+function processWorker(workerArgs, callback) {
+  if (!sharedWorker) {
+    sharedWorker = new InlineWorker(function() {
       var INT8_MAX = 127;
       var INT8_MIN = -128;
 
@@ -47,6 +30,7 @@ function getAudioDecoder(options, callback) {
         var amplitude_scale = evt.data.amplitude_scale;
         var split_channels = evt.data.split_channels;
         var audio_buffer = evt.data.audio_buffer;
+        var job_id = evt.data.job_id;
 
         var channels = audio_buffer.channels;
         var output_channels = split_channels ? channels.length : 1;
@@ -147,20 +131,47 @@ function getAudioDecoder(options, callback) {
           }
         }
 
-        this.postMessage(data_object);
+        this.postMessage({ job_id: job_id, result: data_object });
       });
     });
+    sharedWorker.addEventListener("message", function(evt) {
+      var job_id = evt.data.job_id;
+      var data_object = evt.data.result;
 
-    worker.addEventListener("message", function(evt) {
-      var data_object = evt.data;
-
-      callback(
-        null,
-        new WaveformData(data_object.buffer),
-        audio_buffer
-      );
+      jobCallbacks[job_id](data_object);
+      // We're only sending a single message to each listener, so
+      // remove the callback afterwards to avoid leaks.
+      delete jobCallbacks[job_id];
     });
+  }
+  workerArgs.job_id = jobId++;
+  jobCallbacks[workerArgs.job_id] = callback;
+  sharedWorker.postMessage(workerArgs);
+}
 
+/**
+ * This callback is executed once the audio has been decoded by the browser and
+ * resampled by waveform-data.
+ *
+ * @callback onAudioResampled
+ * @param {Error?}
+ * @param {WaveformData} waveform_data Waveform instance of the browser decoded audio
+ * @param {AudioBuffer} audio_buffer Decoded audio buffer
+ */
+
+/**
+ * AudioBuffer-based WaveformData generator
+ *
+ * Adapted from BlockFile::CalcSummary in Audacity, with permission.
+ * @see https://code.google.com/p/audacity/source/browse/audacity-src/trunk/src/BlockFile.cpp
+ *
+ * @param {Object.<{scale: Number, amplitude_scale: Number, split_channels: Boolean}>} options
+ * @param {onAudioResampled} callback
+ * @returns {Function.<AudioBuffer>}
+ */
+
+function getAudioDecoder(options, callback) {
+  return function onAudioDecoded(audio_buffer) {
     // Construct a simple object with the necessary AudioBuffer data,
     // as we cannot send an AudioBuffer to a Web Worker.
     var audio_buffer_obj = {
@@ -174,11 +185,15 @@ function getAudioDecoder(options, callback) {
       audio_buffer_obj.channels[channel] = audio_buffer.getChannelData(channel);
     }
 
-    worker.postMessage({
+    var worker_args = {
       scale: options.scale,
       amplitude_scale: options.amplitude_scale,
       split_channels: options.split_channels,
       audio_buffer: audio_buffer_obj
+    };
+
+    processWorker(worker_args, function(data_object) {
+      callback(null, new WaveformData(data_object.buffer), audio_buffer);
     });
   };
 }


### PR DESCRIPTION
Prior to this, a new web worker is created for each audio-decoding job, and never cleaned up. How about this, which creates a single web worker that's re-used for successive calls to getAudioDecoder ?

(This also has the happy accident of fixing a memory leak we were seeing in Chrome where it seemed like the underlying audio buffer was never cleaned up.  It's not entirely obvious why, but not cleaning up the event listener here: https://github.com/bbc/waveform-data.js/blob/6bdd6e74cd02916dc0a2cb67ef6af928c7a1dce3/lib/builders/audiodecoder.js#L154-L162 :  meant that audio_buffer never got released)