### PR TITLE
Don't use block-scoped local variables to fix older browsers support

### DIFF
--- a/lib/adapters/arraybuffer.js
+++ b/lib/adapters/arraybuffer.js
@@ -29,11 +29,11 @@ function WaveformDataArrayBufferAdapter(buffer) {
  */
 
 WaveformDataArrayBufferAdapter.isCompatible = function isCompatible(data) {
-  const isCompatible = data && typeof data === "object" && "byteLength" in data;
+  var isCompatible = data && typeof data === "object" && "byteLength" in data;
 
   if (isCompatible) {
-    const view = new DataView(data);
-    const version = view.getInt32(0, true);
+    var view = new DataView(data);
+    var version = view.getInt32(0, true);
 
     if (version !== 1 && version !== 2) {
       throw new TypeError("This waveform data version not supported.");

--- a/lib/adapters/object.js
+++ b/lib/adapters/object.js
@@ -106,7 +106,7 @@ WaveformDataObjectAdapter.prototype = {
    */
 
   at: function at_sample(index) {
-    const data = this._data.data;
+    var data = this._data.data;
 
     if (index >= 0 && index < data.length) {
       return data[index];

--- a/lib/builders/audiodecoder.js
+++ b/lib/builders/audiodecoder.js
@@ -34,18 +34,18 @@ function processWorker(workerArgs, callback) {
       var total_size = header_size + data_length * 2 * output_channels;
       var data_object = new DataView(new ArrayBuffer(total_size));
 
-      var min_value = new Array(output_channels);
-      var max_value = new Array(output_channels);
-
-      for (let channel = 0; channel < output_channels; channel++) {
-        min_value[channel] = Infinity;
-        max_value[channel] = -Infinity;
-      }
-
       var scale_counter = 0;
       var buffer_length = audio_buffer.length;
       var offset = header_size;
       var channel, i;
+
+      var min_value = new Array(output_channels);
+      var max_value = new Array(output_channels);
+
+      for (channel = 0; channel < output_channels; channel++) {
+        min_value[channel] = Infinity;
+        max_value[channel] = -Infinity;
+      }
 
       data_object.setInt32(0, version, true); // Version
       data_object.setUint32(4, 1, true); // Is 8 bit?

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -29,7 +29,7 @@ function WaveformDataChannel(waveformData, channelIndex) {
  */
 
 WaveformDataChannel.prototype.min_sample = function(index) {
-  const offset = (index * this._waveformData.channels + this._channelIndex) * 2;
+  var offset = (index * this._waveformData.channels + this._channelIndex) * 2;
 
   return this._waveformData._adapter.at(offset);
 };
@@ -50,7 +50,7 @@ WaveformDataChannel.prototype.min_sample = function(index) {
  */
 
 WaveformDataChannel.prototype.max_sample = function(index) {
-  const offset = (index * this._waveformData.channels + this._channelIndex) * 2 + 1;
+  var offset = (index * this._waveformData.channels + this._channelIndex) * 2 + 1;
 
   return this._waveformData._adapter.at(offset);
 };

--- a/lib/core.js
+++ b/lib/core.js
@@ -45,7 +45,7 @@ function WaveformData(data) {
 
   this._channels = [];
 
-  for (let channel = 0; channel < this.channels; channel++) {
+  for (var channel = 0; channel < this.channels; channel++) {
     this._channels[channel] = new WaveformDataChannel(this, channel);
   }
 }
@@ -187,7 +187,9 @@ WaveformData.prototype = {
     var min = new Array(channels);
     var max = new Array(channels);
 
-    for (let channel = 0; channel < channels; ++channel) {
+    var channel;
+
+    for (channel = 0; channel < channels; ++channel) {
       if (input_buffer_size > 0) {
         min[channel] = this.channel(channel).min_sample(input_index);
         max[channel] = this.channel(channel).max_sample(input_index);
@@ -218,7 +220,7 @@ WaveformData.prototype = {
     while (input_index < input_buffer_size) {
       while (Math.floor(sample_at_pixel(output_index) / scale) <= input_index) {
         if (output_index > 0) {
-          for (let channel = 0; channel < channels; ++channel) {
+          for (channel = 0; channel < channels; ++channel) {
             add_sample(min[channel], max[channel]);
           }
         }
@@ -231,7 +233,7 @@ WaveformData.prototype = {
         prev_where = sample_at_pixel(output_index - 1);
 
         if (where !== prev_where) {
-          for (let channel = 0; channel < channels; ++channel) {
+          for (channel = 0; channel < channels; ++channel) {
             min[channel] = max_value;
             max[channel] = min_value;
           }
@@ -246,7 +248,7 @@ WaveformData.prototype = {
       }
 
       while (input_index < stop) {
-        for (let channel = 0; channel < channels; ++channel) {
+        for (channel = 0; channel < channels; ++channel) {
           value = this.channel(channel).min_sample(input_index);
 
           if (value < min[channel]) {
@@ -271,13 +273,13 @@ WaveformData.prototype = {
     if (is_partial_resampling) {
       if ((output_data.length / channel_count) > options.width &&
           input_index !== last_input_index) {
-          for (let channel = 0; channel < channels; ++channel) {
+          for (channel = 0; channel < channels; ++channel) {
             add_sample(min[channel], max[channel]);
           }
       }
     }
     else if (input_index !== last_input_index) {
-      for (let channel = 0; channel < channels; ++channel) {
+      for (channel = 0; channel < channels; ++channel) {
         add_sample(min[channel], max[channel]);
       }
     }


### PR DESCRIPTION
According to:
1. https://caniuse.com/let: let is only supported in Chrome 41+, Safari 10+, Firefox 44+
2. https://caniuse.com/const: const work in "strict mode" in Chrome 41+, Safari 10+

This fix tested in Chrome 23+, Safari 6.2+, Firefox 22+.
Should work on older versions as well, but I have no access to it.

closes #73