### PR TITLE
Don't let decode errors cause an unhandledrejection

### DIFF
--- a/src/waveform-data.js
+++ b/src/waveform-data.js
@@ -102,15 +102,21 @@ function createFromArrayBuffer(audioContext, audioData, options, callback) {
     }
 
     callback(error);
+    // prevent double-calling the callback on errors:
+    callback = function() { };
   }
 
-  audioContext.decodeAudioData(
+  var promise = audioContext.decodeAudioData(
     audioData,
     function(audio_buffer) {
       createFromAudioBuffer(audio_buffer, options, callback);
     },
     errorCallback
   );
+
+  if (promise) {
+    promise.catch(errorCallback);
+  }
 }
 
 /**

--- a/test/unit/builders/webaudio.js
+++ b/test/unit/builders/webaudio.js
@@ -39,6 +39,43 @@ export default function waveformDataAudioContextTests(WaveformData) {
           });
         });
 
+        it("shouldn't cause an unhandledrejection on error", function(done) {
+          var options = {
+            audio_context: audioContext,
+            array_buffer: new ArrayBuffer(1024)
+          };
+
+          function listener() {
+            done("This shouldn't be reached");
+          }
+          window.addEventListener("unhandledrejection", listener);
+
+          WaveformData.createFromAudio(options, function(err, waveform) {
+            expect(err).to.be.an.instanceOf(DOMException);
+            setTimeout(function() {
+              window.removeEventListener("unhandledrejection", listener);
+              done();
+            });
+          });
+        });
+
+        it("should only invoke the callback once on error", function(done) {
+          var options = {
+            audio_context: audioContext,
+            array_buffer: new ArrayBuffer(1024)
+          };
+          var count = 0;
+
+          WaveformData.createFromAudio(options, function(err, waveform) {
+            expect(err).to.be.an.instanceOf(DOMException);
+            count++;
+            setTimeout(function() {
+              expect(count).to.eq(1);
+              done();
+            });
+          });
+        });
+
         it("should return a valid waveform", function(done) {
           var options = {
             audio_context: audioContext,


### PR DESCRIPTION
Modern browsers return a promise from `audioContext.decodeAudioData`, but waveform-data doesn't do anything with it.
If decoding fails, this results in an unhandledrejection event, despite the error having already been handled by the old-fashioned error callback [here](https://github.com/bbc/waveform-data.js/blob/463a5f50e0485ba339b08cf3317fc482d6fba8b4/src/waveform-data.js#L104)

How about this PR, which automatically `catch`s the returned promise, invoking the error callback if necessary?

---

PS - 
I see a number of test failures when running this locally (M1 Mac with Chrome 95). They're not caused by my changes - not sure if Chrome's audioDecoder has slightly changed the arraybuffer resulting from decodeAudioData or what. eg:

```
    .createFromAudio
      given an AudioBuffer
        ✗ should return a valid waveform
	Error: Uncaught AssertionError: expected 188 to equal 173 (node_modules/chai/lib/chai/assertion.js:152:1 <- test/unit/tests-browser.js:12024)

        ✗ should return a valid waveform without using a worker
	AssertionError: expected 188 to equal 173
	    at test/unit/builders/audiobuffer.js:56:40 <- test/unit/tests-browser.js:20031:42
	    at createFromAudioBuffer (src/waveform-data.js:73:5 <- test/unit/tests-browser.js:7656:7)
	    at Function.WaveformData.createFromAudio (src/waveform-data.js:141:12 <- test/unit/tests-browser.js:7759:16)
	    at Context.<anonymous> (test/unit/builders/audiobuffer.js:48:24 <- test/unit/tests-browser.js:20024:26)

        ✗ should adjust the length of the waveform when using a different scale
	Error: Uncaught AssertionError: expected 750 to equal 690 (node_modules/chai/lib/chai/assertion.js:152:1 <- test/unit/tests-browser.js:12024)

        ✓ should return waveform data points
        ✓ should return correctly scaled waveform data points
      ✓ should throw if an AudioContext is given as the first argument
      given an AudioContext and ArrayBuffer
        ✓ should return an error if the audio buffer is invalid
        ✓ shouldn't cause an unhandledrejection on error
        ✓ should only invoke the callback once on error
        ✗ should return a valid waveform
	Error: Uncaught AssertionError: expected 188 to equal 173 (node_modules/chai/lib/chai/assertion.js:152:1 <- test/unit/tests-browser.js:12024)

        ✗ should return a valid waveform without using a worker
	Error: Uncaught AssertionError: expected 188 to equal 173 (node_modules/chai/lib/chai/assertion.js:152:1 <- test/unit/tests-browser.js:12024)

        ✗ should return the decoded audio
	Error: Uncaught AssertionError: expected 96000 to equal 88200 (node_modules/chai/lib/chai/assertion.js:152:1 <- test/unit/tests-browser.js:12024)

        ✗ should adjust the length of the waveform when using a different scale
	Error: Uncaught AssertionError: expected 750 to equal 690 (node_modules/chai/lib/chai/assertion.js:152:1 <- test/unit/tests-browser.js:12024)
```