### PR TITLE
Add ability to generate 16 bit output samples in Javascript API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "waveform-data",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "LGPL-3.0",
       "devDependencies": {
         "@babel/preset-env": "~7.22.10",

--- a/src/waveform-data.js
+++ b/src/waveform-data.js
@@ -31,6 +31,7 @@ function WaveformData(data) {
 
 var defaultOptions = {
   scale: 512,
+  bytes_per_output_sample: 1,
   amplitude_scale: 1.0,
   split_channels: false,
   disable_worker: false
@@ -39,6 +40,8 @@ var defaultOptions = {
 function getOptions(options) {
   var opts = {
     scale: options.scale || defaultOptions.scale,
+    bytes_per_output_sample: options.bytes_per_output_sample ||
+        defaultOptions.bytes_per_output_sample,
     amplitude_scale: options.amplitude_scale || defaultOptions.amplitude_scale,
     split_channels: options.split_channels || defaultOptions.split_channels,
     disable_worker: options.disable_worker || defaultOptions.disable_worker
@@ -63,6 +66,7 @@ function createFromAudioBuffer(audio_buffer, options, callback) {
   if (options.disable_worker) {
     var buffer = generateWaveformData({
       scale: options.scale,
+      bytes_per_output_sample: options.bytes_per_output_sample,
       amplitude_scale: options.amplitude_scale,
       split_channels: options.split_channels,
       length: audio_buffer.length,
@@ -81,6 +85,7 @@ function createFromAudioBuffer(audio_buffer, options, callback) {
 
     worker.postMessage({
       scale: options.scale,
+      bytes_per_output_sample: options.bytes_per_output_sample,
       amplitude_scale: options.amplitude_scale,
       split_channels: options.split_channels,
       length: audio_buffer.length,

--- a/src/waveform-generator.js
+++ b/src/waveform-generator.js
@@ -8,6 +8,8 @@
 
  var INT8_MAX = 127;
  var INT8_MIN = -128;
+var INT16_MAX = 32767;
+var INT16_MIN = -32768;
 
  function calculateWaveformDataLength(audio_sample_count, scale) {
    var data_length = Math.floor(audio_sample_count / scale);
@@ -34,7 +36,8 @@ function generateWaveformData(options) {
   var version = output_channels === 1 ? 1 : 2;
   var header_size = version === 1 ? 20 : 24;
   var data_length = calculateWaveformDataLength(length, scale);
-  var total_size = header_size + data_length * 2 * output_channels;
+    var total_size = header_size + data_length * 2 * options.bytes_per_output_sample
+        * output_channels;
   var buffer = new ArrayBuffer(total_size);
   var data_view = new DataView(buffer);
 
@@ -50,8 +53,18 @@ function generateWaveformData(options) {
     max_value[channel] = -Infinity;
   }
 
+    var rangeMin, rangeMax;
+
+    if (options.bytes_per_output_sample === 2) {
+        rangeMax = INT16_MAX;
+        rangeMin = INT16_MIN;
+    }
+    else {
+        rangeMax = INT8_MAX;
+        rangeMin = INT8_MIN;
+    }
   data_view.setInt32(0, version, true); // Version
-  data_view.setUint32(4, 1, true); // Is 8 bit?
+    data_view.setUint32(4, options.bytes_per_output_sample !== 2, true); // Is 8 bit?
   data_view.setInt32(8, sample_rate, true); // Sample rate
   data_view.setInt32(12, scale, true); // Scale
   data_view.setInt32(16, data_length, true); // Length
@@ -68,41 +81,41 @@ function generateWaveformData(options) {
         sample += channels[channel][i];
       }
 
-      sample = Math.floor(INT8_MAX * sample * amplitude_scale / channels.length);
+            sample = Math.floor(rangeMax * sample * amplitude_scale / channels.length);
 
       if (sample < min_value[0]) {
         min_value[0] = sample;
 
-        if (min_value[0] < INT8_MIN) {
-          min_value[0] = INT8_MIN;
+                if (min_value[0] < rangeMin) {
+                    min_value[0] = rangeMin;
         }
       }
 
       if (sample > max_value[0]) {
         max_value[0] = sample;
 
-        if (max_value[0] > INT8_MAX) {
-          max_value[0] = INT8_MAX;
+                if (max_value[0] > rangeMax) {
+                    max_value[0] = rangeMax;
         }
       }
     }
     else {
       for (channel = 0; channel < output_channels; ++channel) {
-        sample = Math.floor(INT8_MAX * channels[channel][i] * amplitude_scale);
+                sample = Math.floor(rangeMax * channels[channel][i] * amplitude_scale);
 
         if (sample < min_value[channel]) {
           min_value[channel] = sample;
 
-          if (min_value[channel] < INT8_MIN) {
-            min_value[channel] = INT8_MIN;
+                    if (min_value[channel] < rangeMin) {
+                        min_value[channel] = rangeMin;
           }
         }
 
         if (sample > max_value[channel]) {
           max_value[channel] = sample;
 
-          if (max_value[channel] > INT8_MAX) {
-            max_value[channel] = INT8_MAX;
+                    if (max_value[channel] > rangeMax) {
+                        max_value[channel] = rangeMax;
           }
         }
       }
@@ -110,8 +123,15 @@ function generateWaveformData(options) {
 
     if (++scale_counter === scale) {
       for (channel = 0; channel < output_channels; channel++) {
+                if (options.bytes_per_output_sample === 2) {
+                    data_view.setInt16(offset, min_value[channel],true);
+                    data_view.setInt16(offset + 2, max_value[channel],true);
+                    offset += 4;
+                }
+                else {
         data_view.setInt8(offset++, min_value[channel]);
         data_view.setInt8(offset++, max_value[channel]);
+                }
 
         min_value[channel] = Infinity;
         max_value[channel] = -Infinity;
@@ -123,10 +143,16 @@ function generateWaveformData(options) {
 
   if (scale_counter > 0) {
     for (channel = 0; channel < output_channels; channel++) {
+            if (options.bytes_per_output_sample === 2) {
+                data_view.setInt16(offset, min_value[channel], true);
+                data_view.setInt16(offset + 2, max_value[channel], true);
+            }
+            else {
       data_view.setInt8(offset++, min_value[channel]);
       data_view.setInt8(offset++, max_value[channel]);
     }
   }
+    }
 
   return buffer;
 }

--- a/waveform-data.d.ts
+++ b/waveform-data.d.ts
@@ -9,6 +9,11 @@ declare module 'waveform-data' {
     scale?: number;
 
     /**
+     * Specify 1 or two byte (8 or 16 bit).  Default = 1
+     */
+
+    bytes_per_output_sample?: number;
+    /**
      * Amplitude scale. Default: 1.0
      */
 


### PR DESCRIPTION
Adds a new option to createFromAudio - `bytes_per_output_sample` can be set to 2 to generate 16 bit, any other value generates 8 bit (the default)