### PR TITLE
Add disable_worker option to base Options type

### DIFF
--- a/waveform-data.d.ts
+++ b/waveform-data.d.ts
@@ -25,6 +25,12 @@ declare module 'waveform-data' {
      */
 
     split_channels?: boolean;
+
+    /**
+     * Set to `true` to disable use of a Web Worker. Default: false
+     */
+
+    disable_worker?: boolean;
   }
 
   export interface WaveformDataAudioContextOptions extends Options {


### PR DESCRIPTION
The `disable_worker` option was added in #90 but the TypeScript definitions weren't updated. This fixes that! 🌈 