### PR TITLE
Add `slice` method to WaveformData type for extracting portions of waveform data

### DIFF
--- a/waveform-data.d.ts
+++ b/waveform-data.d.ts
@@ -217,6 +217,14 @@ declare module 'waveform-data' {
      */
 
     toArrayBuffer: () => ArrayBuffer;
+
+    /**
+     * Extracts a portion of the waveform data and returns it as a new WaveformData object.
+     * Accepts either time-based parameters (startTime/endTime) or index-based parameters (startIndex/endIndex). 
+     * The returned object preserves all original metadata (sample rate, channels, bits, etc.) but contains only the specified range of samples.
+     */
+
+    slice(options: { startTime: number; endTime: number } | { startIndex: number; endIndex: number }): WaveformData;
   }
 
   export default WaveformData;


### PR DESCRIPTION
## Add TypeScript definitions for `slice()` method

### 📋 Summary

This PR adds TypeScript type definitions for the existing `slice()` method in the WaveformData class. The method was previously implemented in JavaScript but was missing from the TypeScript definitions file.

### 🚀 What's Changed

- Added TypeScript interface definition for the `slice()` method in `waveform-data.d.ts`
- The method signature supports both time-based and index-based slicing options
- Includes comprehensive JSDoc documentation

### 🔧 Method Signature

```typescript
slice(options: { startTime: number; endTime: number } | { startIndex: number; endIndex: number }): WaveformData;
```
### 🔄 Backward Compatibility

This change is fully backward compatible as it only adds TypeScript definitions for an existing JavaScript method. No breaking changes are introduced.